### PR TITLE
Remove redundancy in find teammates page

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -47,10 +47,10 @@ router.post(
   function (req, res) {}
 );
 
-//LOGOUT
-router.get("/logout", function (req, res) {
-  req.logout();
-  res.redirect("/");
-});
+// //LOGOUT
+// router.get("/logout", function (req, res) {
+//   req.logout();
+//   res.redirect("/");
+// });
 
 module.exports = router;


### PR DESCRIPTION
#11 
Issue - Repetition of teammates in find teammates page.

Idea - If a teammate is already present in the 'requser' array (array used to store teammates) then don't add the teammate again in the array. 

![Code](https://user-images.githubusercontent.com/100699709/157620164-07684df4-1d9d-447d-bbdd-52f5c5908cff.png)

The check of whether a teammate is present in the array or not can be done by looping through the array and comparing the unique _ids of the array items and the current teammate. If a teammate with the same _id is found in the array, then it is not added again, thus preventing repetition.

Also, if there is the same teammate under mentor and mentee, then to show only one of them can be achieved by checking if there is another teammate with the same name and discord id already present in the array. The check can be performed by looping through the array and comparing name and discord ids. If a teammate with the same name and discord id is found in the array then the current teammate is not added.  

I have also fixed some minor issues like when the user selects no or only one skill using simple if-else statements as they were part of the same post request and were previously giving wrong results.

Before - There is repetition of teammates and the same teammate under mentor and mentee is displayed twice.

![BeforeCode](https://user-images.githubusercontent.com/100699709/157621424-3142da74-a626-4637-b2ce-c427d7b11d97.png)

After code changes - There is no repetition of teammates and the same teammate under mentor and mentee is displayed once.

![AfterCode](https://user-images.githubusercontent.com/100699709/157626189-589173e6-609d-4d9a-ba8a-7edfb9318082.png)


