### PR TITLE
Make Search Results More Relevant To The Topic Searched

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ const mongo_database = process.env.MONGO_REMOTE;
 mongoose.connect(
 
  `mongodb+srv://${mongo_username}:${mongo_password}@cluster0.ca1bc.mongodb.net/UserDB`,
- 
+
   `${mongo_database}`,
   {
     useNewUrlParser: true,

--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -49,6 +49,27 @@ function stopVideo() {
   player.stopVideo();
 }
 
+const arr = ["UC4DwZ2VXM2KWtzHjVk9M_xg",
+"UCjdRbKZ494DfZ4zeX19rICw",
+"UC4MZ7zUHb5eAxU75Dc_nqdQ",
+"UC5DNytAJ6_FISueUfzZCVsw",
+"UCl5-BV9aRaeDVohpE4sqJiQ",
+"UCKMjvg6fB6WS5WrPtbV4F5g",
+"UCTdMIOkg4a3LLaGC0BbHR8g",
+"UCxA99Yr6P_tZF9_BgtMGAWA",
+"UC0hNd2uW8jTR5K3KBzRuG2A",
+"UCBgJ7yrU2sdhl4JWUNhnj2w",
+"UC8ME0E1icwddCikdomxrIVw",
+"UCV-AVH8pbyU9rjt4EUr3fgg",
+"UCuQ0v3Q5_UCLQkp8AwHDNAA",
+"UCpas7--oxQOMwGt852OPF6Q",
+"UCdngmbVKX1Tgre699-XLlUA",
+"UCDCFIqDZ1QUqivxVFQDxS0w",
+"UC7EXDnU9c8XMXwBEuQjFdFA",
+"UC2sSCxCZqL55QTXl3TD0Dbw",
+"UCkeSKp49ycaZRlGKkCRRi1g",
+"UC-86prgPyis3DB4hy6tlT5A"];
+
 $(document).ready(function () {
   var youtube_key = "AIzaSyBHA1Itn4r8RPJZ2Owkib9jCMBPWpEcYVU";
   var video = "";
@@ -58,29 +79,40 @@ $(document).ready(function () {
 
     var search = $("#search").val();
 
-    videoSearch(youtube_key, search, 10);
+    videoSearch(youtube_key, search, 1);
   });
 
   function videoSearch(key, search, maxResults) {
     $("#videos").empty();
 
-    $.get(
-      "https://www.googleapis.com/youtube/v3/search?key=" +
-        youtube_key +
-        "&type=video&videoEmbeddable=true&part=snippet&maxResults=" +
-        maxResults +
-        "&q=%23%23girlsintech%26%26" +
-        search,
-      function (data) {
-        data.items.forEach((item) => {
-          video = `
-                <iframe width="440" height="335" src="https://www.youtube-nocookie.com/embed/${item.id.videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="margin-right: 5%; margin-top: 5%; margin-left: 5%;"></iframe>
-                `;
-
-          $("#videos").append(video);
-        });
-      }
-    );
+    for(var i=0; i<arr.length; i++){
+      const channel_Id = arr[i];
+      const searchTopic = search.toUpperCase().replace(/\s|-/g, "");
+      $.get(
+        "https://www.googleapis.com/youtube/v3/search?key=" +
+          youtube_key +
+          "&type=video&videoEmbeddable=true&part=snippet&maxResults=" +
+          maxResults +
+          "&q=" +
+          search +
+          "&topicId=" +
+          search +
+          "&channelId=" +
+          channel_Id,
+        function (data) {
+          data.items.forEach((item) => {
+            const videoTitle = item.snippet.title.toUpperCase().replace(/\s|-/g, "");
+            const videoDescription = item.snippet.description.toUpperCase().replace(/\s/g, "");
+            if((videoTitle.includes(searchTopic)) || (videoDescription.includes(searchTopic))){
+              video = `
+                    <iframe width="440" height="335" src="https://www.youtube-nocookie.com/embed/${item.id.videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="margin-right: 5%; margin-top: 5%; margin-left: 5%;"></iframe>
+                    `;
+              $("#videos").append(video);
+            }
+          });
+        }
+      );
+    }
   }
 });
 


### PR DESCRIPTION
#18 
Issue: The YouTube videos fetched on entering the keyword in the search bar are not specific to the topic searched.

Solved: By storing the channelIds of all the YouTube channels solely run by women and non-binary individuals who have tutorials on various tech topics in an array. The YouTube API fetches one video from each of these channels which is most relevant to the topic searched. It might be possible that the most relevant video according to the YouTube algorithm is not related to the topic. To check if the video is related to the topic or not can be done by checking if the keyword entered in the search bar is present in the video title or description. The video is displayed only if the keyword is present in the title or description of the video. 

Thus, this method ensures that the tutorials fetched are made only by women and non-binary individuals and are specific to the topic searched.

https://user-images.githubusercontent.com/100699709/163706270-041179fc-d54a-4db4-a92c-12db33948de5.mp4


